### PR TITLE
feat: set default trigger class to TV

### DIFF
--- a/Assets/Scripts/YoloRecognitionHandler.cs
+++ b/Assets/Scripts/YoloRecognitionHandler.cs
@@ -16,7 +16,7 @@ namespace Assets.Scripts
         private GameObject labelObject;
 
         [SerializeField]
-        private ObjectClass triggerClass = ObjectClass.Tv;
+        private ObjectClass triggerClass = ObjectClass.Cup;
 
         [SerializeField]
         [Range(0f, 1f)]

--- a/Assets/Scripts/YoloRecognitionHandler.cs
+++ b/Assets/Scripts/YoloRecognitionHandler.cs
@@ -146,9 +146,14 @@ namespace Assets.Scripts
                 // Show debug information
                 yoloDebugOutput.ShowDebugInformationForItem(item);
 
-                if (item.YoloItem.MostLikelyClass == triggerClass && item.YoloItem.Confidence >= triggerConfidence)
+                // Always log recognition details
+                Debug.Log($"[YOLO] Found: {item.YoloItem.MostLikelyClass} ({item.YoloItem.Confidence:0.00}), " +
+                          $"TriggerClass={triggerClass}, TriggerConfidence={triggerConfidence:0.00}");
+
+                if (item.YoloItem.MostLikelyClass == triggerClass &&
+                    item.YoloItem.Confidence >= triggerConfidence)
                 {
-                    Debug.Log($"Triggering custom action for {triggerClass} with confidence {item.YoloItem.Confidence}");
+                    Debug.LogWarning($"=== TRIGGERED {triggerClass} ({item.YoloItem.Confidence:0.00}) ===");
                     // TODO: Replace with API call or custom action
                 }
             }

--- a/Assets/Scripts/YoloRecognitionHandler.cs
+++ b/Assets/Scripts/YoloRecognitionHandler.cs
@@ -15,6 +15,13 @@ namespace Assets.Scripts
         [SerializeField]
         private GameObject labelObject;
 
+        [SerializeField]
+        private ObjectClass triggerClass = ObjectClass.Tv;
+
+        [SerializeField]
+        [Range(0f, 1f)]
+        private float triggerConfidence = 0.8f;
+
         private YoloDebugOutput yoloDebugOutput;
 
         private void Start()
@@ -138,6 +145,12 @@ namespace Assets.Scripts
 
                 // Show debug information
                 yoloDebugOutput.ShowDebugInformationForItem(item);
+
+                if (item.YoloItem.MostLikelyClass == triggerClass && item.YoloItem.Confidence >= triggerConfidence)
+                {
+                    Debug.Log($"Triggering custom action for {triggerClass} with confidence {item.YoloItem.Confidence}");
+                    // TODO: Replace with API call or custom action
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- default `YoloRecognitionHandler` trigger to TV instead of Person

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a316a326f883288444fac6bbbcca79