### PR TITLE
Throttle cup detection logging to reduce slowdown

### DIFF
--- a/Assets/Scripts/DisplayedItem.cs
+++ b/Assets/Scripts/DisplayedItem.cs
@@ -19,6 +19,7 @@ namespace Assets.Scripts
             this.TimesSeen = 1;
             this.PositionInSpace = positionInSpace;
             this.IsInCameraView = true;
+            this.ActionTriggered = false;
         }
 
         /// <summary>
@@ -50,6 +51,11 @@ namespace Assets.Scripts
         ///     Tracking marker for the recognized item.
         /// </summary>
         public GameObject TrackingMarker { get; set; }
+
+        /// <summary>
+        ///     Indicates if an action has already been triggered for this item.
+        /// </summary>
+        public bool ActionTriggered { get; set; }
 
         /// <summary>
         ///     Updates the item with new information from the current frame.

--- a/Assets/Scripts/YoloRecognitionHandler.cs
+++ b/Assets/Scripts/YoloRecognitionHandler.cs
@@ -138,6 +138,13 @@ namespace Assets.Scripts
 
                 // Show debug information
                 yoloDebugOutput.ShowDebugInformationForItem(item);
+
+                // Announce detection of a cup once to reduce overhead
+                if (!item.ActionTriggered && item.YoloItem.MostLikelyClass == ObjectClass.Cup && item.YoloItem.Confidence >= 0.8f)
+                {
+                    Debug.Log($"Cup detected ({Math.Round(item.YoloItem.Confidence * 100, 1)}%)");
+                    item.ActionTriggered = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- track whether a detection has already triggered an action
- log cup detections once when confidence exceeds 80%

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ae1ac83483288c6cba272801f351